### PR TITLE
Global settings support

### DIFF
--- a/extension_info.json
+++ b/extension_info.json
@@ -7,6 +7,7 @@
         "klavotools/background/deferred-notification.js",
         "klavotools/background/competitions.js",
         "klavotools/background/competitions-ws.js",
+        "klavotools/background/competitions-xhr.js",
         "klavotools/background/content-js.js",
         "klavotools/background/content-style.js",
         "klavotools/background/context-menus.js",

--- a/extension_info.json
+++ b/extension_info.json
@@ -26,7 +26,7 @@
         "klavotools/foreground/context-menu.js"
     ],
     "homepage_url": "http://klavogonki.ru/",
-    "version": "3.3.5",
+    "version": "3.3.6",
     "browser_button": {
         "caption": "KlavoTools",
         "icon": "icons/button.png",

--- a/extension_info.json
+++ b/extension_info.json
@@ -9,6 +9,7 @@
         "klavotools/background/competitions.js",
         "klavotools/background/competitions-ws.js",
         "klavotools/background/competitions-xhr.js",
+        "klavotools/background/unread-pm-counter.js",
         "klavotools/background/content-js.js",
         "klavotools/background/content-style.js",
         "klavotools/background/context-menus.js",

--- a/extension_info.json
+++ b/extension_info.json
@@ -6,6 +6,7 @@
         "klavotools/background/lib/xhr.js",
         "klavotools/background/deferred-notification.js",
         "klavotools/background/competitions.js",
+        "klavotools/background/competitions-ws.js",
         "klavotools/background/content-js.js",
         "klavotools/background/content-style.js",
         "klavotools/background/context-menus.js",

--- a/extension_info.json
+++ b/extension_info.json
@@ -4,6 +4,7 @@
     "background_scripts": [
         "klavotools/background/lib/q.js",
         "klavotools/background/lib/xhr.js",
+        "klavotools/background/lib/mutable-module.js",
         "klavotools/background/deferred-notification.js",
         "klavotools/background/competitions.js",
         "klavotools/background/competitions-ws.js",

--- a/klavotools/background/button.js
+++ b/klavotools/background/button.js
@@ -55,14 +55,21 @@ Button.prototype.setState = function (state) {
  * Handles the AuthStateChanged event and listens for the counters:{userId}/unreadMail
  * site WebSocket events.
  * @param {Auth#AuthStateChanged} event An event with the current session data.
+ * @listens Socket#SocketConnected
+ * @fires SocketSubscribe
  * @listens Socket#counters:{userId}/unreadMail
  * @private
  */
 Button.prototype._update = function (event) {
     var state = event.data;
     if (state.id) {
-        KlavoTools.Socket.on('counters:' + state.id + '/unreadMail', function (data) {
-            this.setState({ authorized: true, unreadMessagesNumber: data.newAmount });
+        kango.addMessageListener('SocketConnected', function (event) {
+            var subscriber = {};
+            subscriber['counters:' + state.id + '/unreadMail'] = function (data) {
+                this.setState({ authorized: true, unreadMessagesNumber: data.newAmount });
+            }.bind(this);
+
+            event.target.dispatchMessage('SocketSubscribe', subscriber);
         }.bind(this));
         this.setState({ authorized: true, unreadMessagesNumber: state.unread_mail });
     } else {

--- a/klavotools/background/button.js
+++ b/klavotools/background/button.js
@@ -61,7 +61,7 @@ Button.prototype.setState = function (state) {
 Button.prototype._update = function (event) {
     var state = event.data;
     if (state.id) {
-        KlavoTools.Auth.on('counters:' + state.id + '/unreadMail', function (data) {
+        KlavoTools.Socket.on('counters:' + state.id + '/unreadMail', function (data) {
             this.setState({ authorized: true, unreadMessagesNumber: data.newAmount });
         }.bind(this));
         this.setState({ authorized: true, unreadMessagesNumber: state.unread_mail });

--- a/klavotools/background/button.js
+++ b/klavotools/background/button.js
@@ -52,25 +52,15 @@ Button.prototype.setState = function (state) {
 };
 
 /**
- * Handles the AuthStateChanged event and listens for the counters:{userId}/unreadMail
- * site WebSocket events.
+ * Handles the AuthStateChanged event.
  * @param {Auth#AuthStateChanged} event An event with the current session data.
- * @listens Socket#SocketConnected
- * @fires SocketSubscribe
- * @listens Socket#counters:{userId}/unreadMail
  * @private
  */
 Button.prototype._update = function (event) {
     var state = event.data;
+    // Saving the user id for later use:
+    this._authId = state.id;
     if (state.id) {
-        kango.addMessageListener('SocketConnected', function (event) {
-            var subscriber = {};
-            subscriber['counters:' + state.id + '/unreadMail'] = function (data) {
-                this.setState({ authorized: true, unreadMessagesNumber: data.newAmount });
-            }.bind(this);
-
-            event.target.dispatchMessage('SocketSubscribe', subscriber);
-        }.bind(this));
         this.setState({ authorized: true, unreadMessagesNumber: state.unread_mail });
     } else {
         this.setState({ authorized: false });
@@ -78,11 +68,30 @@ Button.prototype._update = function (event) {
 };
 
 /**
- * Sets the default button state and listens for AuthStateChanged events.
+ * Sets the default button state and listens for AuthStateChanged events,
+ * with the events related to the counter of unread private messages.
  * @listens Auth#AuthStateChanged
+ * @listens Socket#SocketConnected
+ * @fires SocketSubscribe
+ * @listens Socket#counters:{userId}/unreadMail
+ * @listens UnreadPMCounter#unreadMessagesNumber
  * @private
  */
 Button.prototype._init = function () {
     this.setState({ authorized: false });
     kango.addMessageListener('AuthStateChanged', this._update.bind(this));
+
+    // Using WebSocket connection to get the number of unread PM:
+    kango.addMessageListener('SocketConnected', function (event) {
+        var subscriber = {};
+        subscriber['counters:' + this._authId + '/unreadMail'] = function (data) {
+            this.setState({ authorized: true, unreadMessagesNumber: data.newAmount });
+        }.bind(this);
+        event.target.dispatchMessage('SocketSubscribe', subscriber);
+    }.bind(this));
+
+    // Also subscribing for the UnreadPMCounter#UnreadMessagesNumber event:
+    kango.addMessageListener('UnreadMessagesNumber', function (event) {
+        this.setState({ authorized: true, unreadMessagesNumber: event.data });
+    }.bind(this));
 };

--- a/klavotools/background/competitions-ws.js
+++ b/klavotools/background/competitions-ws.js
@@ -79,14 +79,14 @@ CompetitionsWS.prototype._processInitList = function (list) {
 CompetitionsWS.prototype._init = function() {
     this.addMessageListener('AuthStateChanged', function (event) {
         if (event.data.id) {
-            this.addMessageListener('SocketConnected', function (event) {
+            this.setMessageListener('SocketConnected', function (event) {
                 event.target.dispatchMessage('SocketSubscribe', {
                     'gamelist/initList': this._processInitList.bind(this),
                     'gamelist/gameCreated': this._processCreated.bind(this),
                     'gamelist/gameUpdated': this._processUpdated.bind(this),
                 });
             }.bind(this));
-            this.addMessageListener('ServerTimeDelta', function (event) {
+            this.setMessageListener('ServerTimeDelta', function (event) {
                 this._timeCorrection = event.data;
             }.bind(this))
         }

--- a/klavotools/background/competitions-ws.js
+++ b/klavotools/background/competitions-ws.js
@@ -77,16 +77,16 @@ CompetitionsWS.prototype._processInitList = function (list) {
  * @private
  */
 CompetitionsWS.prototype._init = function() {
-    kango.addMessageListener('AuthStateChanged', function (event) {
+    this.addMessageListener('AuthStateChanged', function (event) {
         if (event.data.id) {
-            kango.addMessageListener('SocketConnected', function (event) {
+            this.addMessageListener('SocketConnected', function (event) {
                 event.target.dispatchMessage('SocketSubscribe', {
                     'gamelist/initList': this._processInitList.bind(this),
                     'gamelist/gameCreated': this._processCreated.bind(this),
                     'gamelist/gameUpdated': this._processUpdated.bind(this),
                 });
             }.bind(this));
-            kango.addMessageListener('ServerTimeDelta', function (event) {
+            this.addMessageListener('ServerTimeDelta', function (event) {
                 this._timeCorrection = event.data;
             }.bind(this))
         }

--- a/klavotools/background/competitions-ws.js
+++ b/klavotools/background/competitions-ws.js
@@ -78,6 +78,7 @@ CompetitionsWS.prototype._processInitList = function (list) {
  */
 CompetitionsWS.prototype._init = function() {
     this.addMessageListener('AuthStateChanged', function (event) {
+        this._clearAll();
         if (event.data.id) {
             this.setMessageListener('SocketConnected', function (event) {
                 event.target.dispatchMessage('SocketSubscribe', {

--- a/klavotools/background/competitions-ws.js
+++ b/klavotools/background/competitions-ws.js
@@ -1,0 +1,94 @@
+/**
+ * @file Extends Competitions class for use with a site WebSocket connection.
+ * @author Daniil Filippov <filippovdaniil@gmail.com>
+ */
+
+/**
+ * @constructor
+ * @extends Competitions
+ */
+function CompetitionsWS () {
+    return Competitions.apply(this, arguments);
+}
+
+CompetitionsWS.prototype.__proto__ = Competitions.prototype;
+
+/**
+ * A handler for the Socket#gamelist/gameUpdated event.
+ * @param {Object} game A hash object with game data diff.
+ * @private
+ */
+CompetitionsWS.prototype._processUpdated = function (game) {
+    if (!this._hash[game.g]) {
+        return false;
+    }
+    if (game.diff && game.diff.begintime) {
+        this._hash[game.g].beginTime = game.diff.begintime;
+        this._notify(game.g);
+    }
+};
+
+/**
+ * A handler for the Socket#gamelist/gameCreated event.
+ * @param {Object} game A hash object with game data.
+ * @private
+ */
+CompetitionsWS.prototype._processCreated = function (game) {
+    if (!game.params || !game.params.competition) {
+        return false;
+    }
+
+    this._hash[game.id] = {
+        id: game.id,
+        ratingValue: game.params.regular_competition || 1,
+        beginTime: game.begintime,
+    }
+
+    if (game.begintime !== null) {
+        this._notify(game.id);
+    }
+
+    this._clearStarted();
+};
+
+/**
+ * A handler for the Socket#gamelist/initList event.
+ * @param {Object[]} list An array with current gamelist data.
+ * @private
+ */
+CompetitionsWS.prototype._processInitList = function (list) {
+    list.forEach(function (game) {
+        if (typeof game.info === 'object') {
+            this._processCreated(game.info);
+        }
+    }, this);
+};
+
+/**
+ * Sets a handler for AuthStateChanged events and listens for changes in the gamelist,
+ * if the user is authorized.
+ * @listens Auth#AuthStateChanged
+ * @listens Socket#SocketConnected
+ * @listens Socket#ServerTimeDelta
+ * @fires SocketSubscribe
+ * @listens Socket#gamelist/initList
+ * @listens Socket#gamelist/gameCreated
+ * @listens Socket#gamelist/gameUpdated
+ * @private
+ */
+CompetitionsWS.prototype._init = function() {
+    kango.addMessageListener('AuthStateChanged', function (event) {
+        if (event.data.id) {
+            kango.addMessageListener('SocketConnected', function (event) {
+                event.target.dispatchMessage('SocketSubscribe', {
+                    'gamelist/initList': this._processInitList.bind(this),
+                    'gamelist/gameCreated': this._processCreated.bind(this),
+                    'gamelist/gameUpdated': this._processUpdated.bind(this),
+                });
+            }.bind(this));
+            kango.addMessageListener('ServerTimeDelta', function (event) {
+                this._timeCorrection = event.data;
+            }.bind(this))
+        }
+    }.bind(this));
+};

--- a/klavotools/background/competitions-xhr.js
+++ b/klavotools/background/competitions-xhr.js
@@ -1,0 +1,115 @@
+/**
+ * @file A "fallback" version of the Competitions module, which uses XHR requests.
+ * Extends Competitions class.
+ * @author Daniil Filippov <filippovdaniil@gmail.com>
+ */
+
+/**
+ * @constructor
+ * @extends Competitions
+ */
+function CompetitionsXHR () {
+    return Competitions.apply(this, arguments);
+}
+
+CompetitionsXHR.prototype.__proto__ = Competitions.prototype;
+
+/**
+ * Extends Competitions.prototype.setParams method with a call of the _check().
+ * @private
+ */
+CompetitionsXHR.prototype.setParams = function () {
+    Competitions.prototype.setParams.apply(this, arguments);
+    this._check();
+};
+
+/**
+ * Processes a single competition data.
+ * @param {Object} competition A hash object with competition data
+ * @private
+ */
+CompetitionsXHR.prototype._processCompetition = function (competition) {
+    if (this._hash[competition.id]) {
+        return false;
+    }
+
+    this._hash[competition.id] = {
+        id: competition.id,
+        ratingValue: competition.params.regular_competition || 1,
+        beginTime: competition.begintime,
+    }
+
+    this._notify(competition.id);
+    this._clearStarted();
+    var remainingTime = this.getRemainingTime(competition.begintime);
+    if (remainingTime > 0) {
+        setTimeout(this._check.bind(this), (remainingTime + 120) * 1000);
+    }
+};
+
+/**
+ * Processes a gamelist data array.
+ * @param {Object[]} gamelist An array with gamelist data
+ * @private
+ */
+CompetitionsXHR.prototype._processGamelist = function (gamelist) {
+    var foundCompetition = false;
+    gamelist.forEach(function (game) {
+        if (game.params && game.params.competition) {
+            foundCompetition = true;
+            this._processCompetition(game);
+        }
+    }, this);
+
+    if (!foundCompetition) {
+        setTimeout(this._check.bind(this), 120 * 1000);
+    }
+};
+
+/**
+ * Fetches the gamelist data with _fetchData() method, and processes it.
+ * @returns {Promise.<(Object|string)>}
+ * @private
+ */
+CompetitionsXHR.prototype._check = function () {
+    return this._fetchData().then(function (data) {
+        this._timeCorrection = data.time - Math.round(Date.now() / 1000);
+        this._processGamelist(data.gamelist);
+    }.bind(this)).catch(function (error) {
+        kango.console.log('Error while fetching gamelist data: ' + error.toString());
+        setTimeout(this._check.bind(this), 10 * 1000);
+    });
+};
+
+/**
+ * Fetches the gamelist data with a XHR request.
+ * @returns {Promise.<(Object|string)>}
+ * @private
+ */
+CompetitionsXHR.prototype._fetchData = function () {
+    return xhr({
+        url: KlavoTools.const.GAMELIST_DATA_URL,
+        method: 'POST',
+        params: { cached_users: 0 },
+        contentType: 'json',
+    }).then(function (data) {
+        if (!data.gamelist || !(data.gamelist instanceof Array)) {
+            return Q.reject('Gamelist data not available');
+        }
+        return data;
+    }.bind(this));
+};
+
+/**
+ * Sets a handler for AuthStateChanged events and calls the _check() method,
+ * if the user is authorized.
+ * @listens Auth#AuthStateChanged
+ * @private
+ */
+CompetitionsXHR.prototype._init = function () {
+    kango.addMessageListener('AuthStateChanged', function (event) {
+        if (event.data.id) {
+            this._check();
+        }
+    }.bind(this));
+};

--- a/klavotools/background/competitions-xhr.js
+++ b/klavotools/background/competitions-xhr.js
@@ -107,7 +107,7 @@ CompetitionsXHR.prototype._fetchData = function () {
  * @private
  */
 CompetitionsXHR.prototype._init = function () {
-    kango.addMessageListener('AuthStateChanged', function (event) {
+    this.addMessageListener('AuthStateChanged', function (event) {
         if (event.data.id) {
             this._check();
         }

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -170,6 +170,20 @@ Competitions.prototype._clearStarted = function () {
 };
 
 /**
+ * Deletes all competitions from the this._hash object.
+ * @private
+ */
+Competitions.prototype._clearAll = function () {
+    for (var id in this._hash) {
+        var competition = this._hash[id];
+        if (competition.notification) {
+            competition.notification.revoke();
+        }
+        delete this._hash[id];
+    }
+};
+
+/**
  * Checks the remaining time before the competition start by its id, creates and saves
  * the new notification instance if needed.
  * @param {number} id An id of the competition
@@ -185,21 +199,15 @@ Competitions.prototype._notify = function (id) {
 };
 
 /**
- * Initialization method to implement.
- * @private
- */
-Competitions.prototype._init = function () {};
-
-
-/**
  * Revokes all deferred notifications on teardown.
  */
 Competitions.prototype.teardown = function () {
     MutableModule.prototype.teardown.apply(this, arguments);
-    for (var id in this._hash) {
-        var competition = this._hash[id];
-        if (competition.notification) {
-            competition.notification.revoke();
-        }
-    }
+    this._clearAll();
 };
+
+/**
+ * Initialization method to implement.
+ * @private
+ */
+Competitions.prototype._init = function () {};

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -130,8 +130,8 @@ Competitions.prototype.getRemainingTime = function (beginTime) {
         throw new TypeError('Wrong argument type for getRemainingTime() method');
     }
 
-    if (typeof this._timeCorrection === 'undefined') {
-        throw new Error('Server time delta is undefined');
+    if (typeof this._timeCorrection !== 'number') {
+        throw new Error('Server time delta is not set');
     }
 
     var remaining = beginTimestamp - (Date.now() + this._timeCorrection);

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -38,6 +38,9 @@ var Competitions = function() {
     this._init();
 };
 
+// Adding the teardown() and addMessageListener() methods to the prototype:
+Competitions.prototype.__proto__ = MutableModule.prototype;
+
 /**
  * Returns current parameters for the options page.
  * @returns {Object}
@@ -186,3 +189,17 @@ Competitions.prototype._notify = function (id) {
  * @private
  */
 Competitions.prototype._init = function () {};
+
+
+/**
+ * Revokes all deferred notifications on teardown.
+ */
+Competitions.prototype.teardown = function () {
+    MutableModule.prototype.teardown.apply(this, arguments);
+    for (var id in this._hash) {
+        var competition = this._hash[id];
+        if (competition.notification) {
+            competition.notification.revoke();
+        }
+    }
+};

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -130,7 +130,7 @@ Competitions.prototype.getRemainingTime = function (beginTime) {
         throw new TypeError('Wrong argument type for getRemainingTime() method');
     }
 
-    var timeCorrection = KlavoTools.Auth.getServerTimeDelta();
+    var timeCorrection = KlavoTools.Socket.getServerTimeDelta();
     if (timeCorrection === null) {
         throw new Error('Server time delta is null');
     }
@@ -230,9 +230,9 @@ Competitions.prototype._processInitList = function (list) {
 Competitions.prototype._init = function() {
     kango.addMessageListener('AuthStateChanged', function (event) {
         if (event.data.id) {
-            KlavoTools.Auth.on('gamelist/initList', this._processInitList.bind(this));
-            KlavoTools.Auth.on('gamelist/gameCreated', this._processCreated.bind(this));
-            KlavoTools.Auth.on('gamelist/gameUpdated', this._processUpdated.bind(this));
+            KlavoTools.Socket.on('gamelist/initList', this._processInitList.bind(this));
+            KlavoTools.Socket.on('gamelist/gameCreated', this._processCreated.bind(this));
+            KlavoTools.Socket.on('gamelist/gameUpdated', this._processUpdated.bind(this));
         }
     }.bind(this));
 };

--- a/klavotools/background/engine.js
+++ b/klavotools/background/engine.js
@@ -12,7 +12,7 @@ var KlavoTools = {
         ICON_UNREAD: 'icons/dic.png',
         WS_BASE_URL: 'ws://klavogonki.ru/ws',
         WS_HEARTBEAT_TIMEOUT: 40,
-
+        GAMELIST_DATA_URL: 'http://klavogonki.ru/gamelist.data?KTS_REQUEST',
     },
     version: function() {
         return kango.getExtensionInfo().version;

--- a/klavotools/background/engine.js
+++ b/klavotools/background/engine.js
@@ -13,6 +13,7 @@ var KlavoTools = {
         WS_BASE_URL: 'ws://klavogonki.ru/ws',
         WS_HEARTBEAT_TIMEOUT: 40,
         GAMELIST_DATA_URL: 'http://klavogonki.ru/gamelist.data?KTS_REQUEST',
+        PM_DATA_URL: 'http://klavogonki.ru/api/profile/get-messages-contacts?KTS_REQUEST',
     },
     version: function() {
         return kango.getExtensionInfo().version;

--- a/klavotools/background/engine.js
+++ b/klavotools/background/engine.js
@@ -12,6 +12,7 @@ var KlavoTools = {
         ICON_UNREAD: 'icons/dic.png',
         WS_BASE_URL: 'ws://klavogonki.ru/ws',
         WS_HEARTBEAT_TIMEOUT: 40,
+
     },
     version: function() {
         return kango.getExtensionInfo().version;
@@ -22,6 +23,7 @@ KlavoTools.UserJS = new UserJS;
 KlavoTools.Skin = new Skin;
 KlavoTools.Competitions = new Competitions;
 KlavoTools.ContextMenus = new ContextMenus;
+KlavoTools.Socket = new Socket;
 KlavoTools.Button = new Button;
 KlavoTools.Auth = new Auth;
 

--- a/klavotools/background/engine.js
+++ b/klavotools/background/engine.js
@@ -21,7 +21,7 @@ var KlavoTools = {
 
 KlavoTools.UserJS = new UserJS;
 KlavoTools.Skin = new Skin;
-KlavoTools.Competitions = new Competitions;
+KlavoTools.Competitions = new CompetitionsWS;
 KlavoTools.ContextMenus = new ContextMenus;
 KlavoTools.Socket = new Socket;
 KlavoTools.Button = new Button;

--- a/klavotools/background/lib/mutable-module.js
+++ b/klavotools/background/lib/mutable-module.js
@@ -12,9 +12,10 @@ function MutableModule () {}
  * @returns {boolean} The result of the kango.addMessageListener call
  */
 MutableModule.prototype.addMessageListener = function (eventName, listener) {
-    if (!this._teardownList) {
+    if (typeof this._teardownList === 'undefined') {
         this._teardownList = [];
     }
+
     this._teardownList.push({
         event: eventName,
         listener: listener,
@@ -23,15 +24,37 @@ MutableModule.prototype.addMessageListener = function (eventName, listener) {
 };
 
 /**
+ * Sets only one handler for the given event name (replaces existing one).
+ * @param {string} eventName An event name
+ * @param {function} listener An event callback function
+ * @returns {boolean} The result of the kango.addMessageListener call
+ */
+MutableModule.prototype.setMessageListener = function (eventName, listener) {
+    var found = this._teardownList.filter(function (item) {
+        return item.event === eventName;
+    })[0];
+
+    if (found) {
+        kango.removeMessageListener(found.event, found.listener);
+        this._teardownList.splice(this._teardownList.indexOf(found), 1);
+    }
+
+    return this.addMessageListener(eventName, listener);
+};
+
+/**
  * Makes some actions before the class instance destroy.
  */
 MutableModule.prototype.teardown = function () {
-    if (!this.teardownList) {
+    if (!this._teardownList) {
         return false;
     }
-    this.teardownList.forEach(function (item) {
+
+    this._teardownList.forEach(function (item) {
         if (item.event) {
             kango.removeMessageListener(item.event, item.listener);
         }
     });
+
+    this._teardownList = [];
 };

--- a/klavotools/background/lib/mutable-module.js
+++ b/klavotools/background/lib/mutable-module.js
@@ -1,0 +1,37 @@
+/**
+ * @file A base class for creating "mutable" modules with teardown() method.
+ * @author Daniil Filippov <filippovdaniil@gmail.com>
+ */
+function MutableModule () {}
+
+/**
+ * Proxies arguments to the kango.addMessageListener and saves them in the _teardownList
+ * array.
+ * @param {string} eventName An event name
+ * @param {function} listener An event callback function
+ * @returns {boolean} The result of the kango.addMessageListener call
+ */
+MutableModule.prototype.addMessageListener = function (eventName, listener) {
+    if (!this._teardownList) {
+        this._teardownList = [];
+    }
+    this._teardownList.push({
+        event: eventName,
+        listener: listener,
+    });
+    return kango.addMessageListener(eventName, listener);
+};
+
+/**
+ * Makes some actions before the class instance destroy.
+ */
+MutableModule.prototype.teardown = function () {
+    if (!this.teardownList) {
+        return false;
+    }
+    this.teardownList.forEach(function (item) {
+        if (item.event) {
+            kango.removeMessageListener(item.event, item.listener);
+        }
+    });
+};

--- a/klavotools/background/socket.js
+++ b/klavotools/background/socket.js
@@ -7,6 +7,7 @@ function Socket () {
     this._authorized = false;
     this._listeners = {};
     this._serverTimeDelta = null;
+    this._init();
 }
 
 /**
@@ -210,6 +211,7 @@ Socket.prototype._onClose = function (deferred, event) {
  * @param {(Event#error|CustomEvent#error)} event An error event.
  * @listens Event#error
  * @listens CustomEvent#error
+ * @fires Socket#SocketError
  * @private
  */
 Socket.prototype._onError = function (event) {
@@ -219,8 +221,22 @@ Socket.prototype._onError = function (event) {
     } else {
         this.disconnect();
     }
-    if (typeof this.onError !== 'function') {
-        return;
-    }
-    this.onError(event);
+    kango.dispatchMessage('SocketError', event);
+};
+
+
+/**
+ * Listens for AuthStateChanged event and creates new WebSocket connection if the user
+ * is authorized.
+ * @listens Auth#AuthStateChanged
+ * @private
+ */
+Socket.prototype._init = function () {
+    kango.addMessageListener('AuthStateChanged', function (event) {
+        if (event.data.id) {
+            this.connect(event.data.id, event.data.one_shot_hash)
+        } else {
+            this.disconnect();
+        }
+    }.bind(this));
 };

--- a/klavotools/background/socket.js
+++ b/klavotools/background/socket.js
@@ -149,7 +149,7 @@ Socket.prototype._handleMessage = function (deferred, message) {
     if (!this._authorized) {
         if (message === 'auth ok') {
             this._authorized = true;
-            this.addMessageListener('SocketSubscribe', this._subscribe.bind(this));
+            this.setMessageListener('SocketSubscribe', this._subscribe.bind(this));
             kango.dispatchMessage('SocketConnected', message);
             deferred.resolve(message);
         } else if (message === 'auth failed') {

--- a/klavotools/background/unread-pm-counter.js
+++ b/klavotools/background/unread-pm-counter.js
@@ -1,0 +1,61 @@
+/**
+ * @file Fetches the number of unread private messages and broadcasts
+ * the UnreadMessagesNumber event. Used only when WebSockets are disabled in settings.
+ * @author Daniil Filippov <filippovdaniil@gmail.com>
+ */
+function UnreadPMCounter () {
+    this._init();
+}
+
+// Adding the teardown() and addMessageListener() methods to the prototype:
+UnreadPMCounter.prototype.__proto__ = MutableModule.prototype;
+
+/**
+ * Fetches the number of unread PM and broadcasts the UnreadMessagesNumber event.
+ * @fires UnreadPMCounter#UnreadMessagesNumber
+ * @returns {Promise.<(Object|string)>}
+ * @private
+ */
+UnreadPMCounter.prototype._check = function () {
+    return xhr({
+        url: KlavoTools.const.PM_DATA_URL,
+        contentType: 'json',
+    }).then(function (data) {
+        if (!data.messages) {
+            return Q.reject('PM data is not available');
+        }
+
+        var unread = 0;
+        data.messages.forEach(function (message) {
+            if (message.folder === 'in') {
+                unread += message.unread;
+            }
+        });
+        kango.dispatchMessage('UnreadMessagesNumber', unread);
+        return Q.resolve(unread);
+    }).catch(function (error) {
+        kango.console.log('Error while fetching PM data: ' + error.toString());
+    })
+};
+
+/**
+ * Clears the check timer on teardown.
+ */
+UnreadPMCounter.prototype.teardown = function () {
+    MutableModule.prototype.teardown.apply(this, arguments);
+    clearTimeout(this._timer);
+};
+
+/**
+ * Listens for the AuthStateChanged events and sets the check timer.
+ * @private
+ */
+UnreadPMCounter.prototype._init = function () {
+    this.addMessageListener('AuthStateChanged', function (event) {
+        clearTimeout(this._timer);
+        if (event.data.id) {
+            this._timer = setInterval(this._check.bind(this), 60 * 1000);
+            this._check();
+        }
+    }.bind(this));
+};

--- a/klavotools/foreground/auth-state.js
+++ b/klavotools/foreground/auth-state.js
@@ -5,10 +5,12 @@
 // ==/UserScript==
 
 try {
-    var link = document.querySelector('.user-dropdown .dropmenu a.btn');
-    if (!link) {
-        throw new ReferenceError('".user-dropwdown .dropmenu a.btn" element not found.');
+    var testPage = document.querySelector('#head .login-block + .menu');
+    if (!testPage) {
+        throw new ReferenceError('Script loaded on the page with no session data');
     }
+
+    var link = document.querySelector('.user-dropdown .dropmenu a.btn');
     var userId = link ? link.href.match(/\d+/)[0] * 1 : null;
     kango.invokeAsync('KlavoTools.Auth.getState', function (state) {
         if (state.id !== userId) {

--- a/klavotools/options/module.js
+++ b/klavotools/options/module.js
@@ -5,6 +5,30 @@ angular.module('klavotools', ['klavotools.joke'])
         $scope.$apply();
     });
 })
+.controller('GlobalSettings', function($scope) {
+    $scope.settings = [];
+    kango.invokeAsync('KlavoTools.Settings.get', function(data) {
+        var settings = [];
+        for (var key in data) {
+            settings.push({
+                name: key,
+                type: typeof data[key],
+                value: data[key],
+            });
+        }
+        $scope.settings = settings;
+    });
+    $scope.$watch('settings', function(newSettings, oldSettings) {
+        if (!newSettings.length || !oldSettings.length) {
+            return false;
+        }
+        var settings = {};
+        newSettings.forEach(function (setting) {
+            settings[setting.name] = setting.value;
+        });
+        kango.invokeAsync('KlavoTools.Settings.set', settings);
+    }, true);
+})
 .controller('StyleCtrl', function($scope) {
     kango.invokeAsync('KlavoTools.Skin.getAll', function(res) {
         $scope.skins = res;
@@ -13,12 +37,12 @@ angular.module('klavotools', ['klavotools.joke'])
                 $scope.active = name;
         }
     });
-    
+
     $scope.$watch('active', function(a, b) {
         for(var name in $scope.skins) {
             $scope.skins[name] = (a == name) ? true : false;
         }
-        
+
         kango.invokeAsync('KlavoTools.Skin.save', a);
     });
 })
@@ -32,10 +56,10 @@ angular.module('klavotools', ['klavotools.joke'])
                 description: scripts[i].desc
             }
         }
-        
+
         $scope.scripts = tmp;
     });
-    
+
     $scope.save = function(script) {
         kango.invokeAsync('KlavoTools.UserJS.set', {
             id: script+'.user.js',
@@ -86,6 +110,13 @@ angular.module('klavotools', ['klavotools.joke'])
         if(typeof b != 'object')
             sendPrefs({delay: parseInt(a)});
     });
+})
+.filter('settingDescription', function () {
+    return function (input) {
+        switch (input) {
+            case 'useWebSockets': return 'Использовать WebSocket соединение с сайтом.';
+        }
+    }
 })
 .filter('skin', function() {
     return function(input) {

--- a/options.html
+++ b/options.html
@@ -58,6 +58,16 @@
 
     <h4>Настройки KlavoTools</h4>
 
+    <b>Глобальные настройки:</b>
+    <form id="KTS_globalSettings" ng:controller="GlobalSettings">
+      <div ng:repeat="setting in settings">
+        <div ng-if="setting.type === 'boolean'">
+          <input type="checkbox" ng-model="setting.value" name="{{setting.name}}" id="KTS_settings_checkbox_{{setting.name}}"/>
+          <label for="KTS_settings_checkbox_{{setting.name}}">{{setting.name | settingDescription}}</label>
+        </div>
+      </div>
+    </form>
+
     <b>Стили:</b>
     <form id="KTS_style" ng:controller="StyleCtrl">
       <div ng:repeat="(skin, value) in skins">

--- a/tests/unit/background/auth.js
+++ b/tests/unit/background/auth.js
@@ -20,21 +20,12 @@ describe('auth module', function () {
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
       sandbox.useFakeTimers();
-      sandbox.stub(Socket.prototype, 'on');
-      sandbox.stub(Socket.prototype, 'connect');
-      sandbox.stub(Socket.prototype, 'disconnect');
       sandbox.stub(kango.xhr, 'send');
       auth = new Auth;
     });
 
     afterEach(function () {
       sandbox.restore();
-    });
-
-    it('should proxy on() calls to the Socket class instance', function (){
-      auth.on('someEvent1', function () {});
-      expect(Socket.prototype.on)
-        .to.have.been.calledWithExactly('someEvent1', sinon.match.func);
     });
 
     it('should fetch the user session state properly', function () {
@@ -73,15 +64,15 @@ describe('auth module', function () {
     it('should call login() method for 10 times before giving up ' +
         'with relogin() method')
 
+    it('should call relogin() method if the login() promise was rejected');
+
+    it('should call relogin() method on SocketError event');
+
     it('should broadcast the AuthStateChanged event to all scripts with ' +
         '_broadcastStateChange() method');
 
     it('should broadcast the user session state after fetching');
 
     it('should broadcast the user session state on logout()');
-
-    it('should create a WebSocket connection if the user is authorized');
-
-    it('should close current WebSocket connection with logout() method');
   });
 });

--- a/tests/unit/background/competitions-ws.js
+++ b/tests/unit/background/competitions-ws.js
@@ -1,0 +1,67 @@
+/**
+ * @file Unit tests for the competitions background module
+ * @author Daniil Filippov <filippovdaniil@gmail.com>
+ */
+
+require('../background.js');
+var sinon = require('sinon');
+var assertStyles = require('../../assert-styles.js');
+var expect = assertStyles.expect;
+var fixtures = require('../../fixtures.js');
+
+describe('competitions module', function () {
+  describe('CompetitionsWS class', function () {
+    // Reference to the sinon sandbox:
+    var sandbox;
+    // Reference to the Competitions class instance:
+    var competitions;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      competitions = new CompetitionsWS;
+      // Set the default server time delta to 1000 milliseconds:
+      competitions._timeCorrection = 1000;
+    });
+
+    afterEach(function () {
+      // Unwraping all stubs and spies:
+      sandbox.restore();
+    });
+
+    it('should update the competition start time on the ' +
+        '"gamelist/gameUpdated" socket event', function () {
+      competitions._hash = {
+        1337: {
+          id: 1337,
+          beginTime: null,
+          ratingValue: 1,
+        },
+      };
+      competitions._processUpdated({
+        g: 1337,
+        diff: {
+          begintime: 1,
+        },
+      });
+      expect(competitions._hash[1337].beginTime).to.be.equal(1);
+      competitions._processUpdated({
+        g: 1338,
+        diff: {
+          begintime: 2,
+        },
+      });
+      expect(competitions._hash[1337].beginTime).to.be.equal(1);
+    });
+
+    it('should add competition data on the "gamelist/gameCreated" ' +
+        'socket event');
+
+    it('should process the gamelist data on the "gamelist/initList" ' +
+        'socket event');
+
+    it('should subscribe for gamelist changes if the user ' +
+        'is authorized');
+
+    it('should set the _timeCorrection field on the ServerTimeDelta event');
+  });
+});

--- a/tests/unit/background/competitions-xhr.js
+++ b/tests/unit/background/competitions-xhr.js
@@ -1,0 +1,53 @@
+/**
+ * @file Unit tests for the competitions background module
+ * @author Daniil Filippov <filippovdaniil@gmail.com>
+ */
+
+require('../background.js');
+var sinon = require('sinon');
+var assertStyles = require('../../assert-styles.js');
+var expect = assertStyles.expect;
+var fixtures = require('../../fixtures.js');
+
+describe('competitions module', function () {
+  describe('CompetitionsXHR class', function () {
+    // Reference to the sinon sandbox:
+    var sandbox;
+    // Reference to the Competitions class instance:
+    var competitions;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      competitions = new CompetitionsXHR;
+    });
+
+    afterEach(function () {
+      // Unwraping all stubs and spies:
+      sandbox.restore();
+    });
+
+    it('should fetch gamelist data with the _fetchData() method');
+
+    it('should reject a _fetchData promise if the gamelist data ' +
+        'is not available');
+
+    it('should set the server time delta with the _check() method');
+
+    it('should call the check() method again after 10 seconds, ' +
+        'if an error has occured');
+
+    it('should call the check() method again after 2 minutes, ' +
+        'if no competitions were found');
+
+    it('should process a gamelist data with the _processGamelist() ' +
+        'method');
+
+    it('should add a competition data with the _processCompetition() ' +
+        'method');
+
+    it('should call the check() method with a 2 minutes delay after ' +
+        'the competition start');
+
+    it('should call the check() method within the _setParams() method');
+  });
+});

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -287,5 +287,7 @@ describe('competitions module', function () {
       competitions._notify(1338);
       expect(Competitions.prototype._createNotification).to.not.been.called;
     });
+
+    it('should revoke all notifications on teardown');
   });
 });

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -30,10 +30,9 @@ describe('competitions module', function () {
       sandbox.spy(global, 'DeferredNotification');
       sandbox.stub(DeferredNotification.prototype, 'revoke');
       sandbox.stub(DeferredNotification.prototype, 'show');
-      sandbox.stub(Socket.prototype, 'getServerTimeDelta');
-      // Set the default server time correction to 1 second:
-      Socket.prototype.getServerTimeDelta.returns(1000);
       competitions = new Competitions;
+      // Set the default server time delta to 1000 milliseconds:
+      competitions._timeCorrection = 1000;
     });
 
     afterEach(function () {
@@ -204,7 +203,7 @@ describe('competitions module', function () {
         'server time delta', function () {
       sandbox.clock.tick(1470230514177);
       expect(competitions.getRemainingTime.bind(competitions, null)).to.throw(TypeError);
-      Socket.prototype.getServerTimeDelta.returns(null);
+      competitions._timeCorrection = null;
       expect(competitions.getRemainingTime.bind(competitions, 1470230614))
         .to.throw(Error);
     });

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -30,9 +30,9 @@ describe('competitions module', function () {
       sandbox.spy(global, 'DeferredNotification');
       sandbox.stub(DeferredNotification.prototype, 'revoke');
       sandbox.stub(DeferredNotification.prototype, 'show');
-      sandbox.stub(Auth.prototype, 'getServerTimeDelta');
+      sandbox.stub(Socket.prototype, 'getServerTimeDelta');
       // Set the default server time correction to 1 second:
-      Auth.prototype.getServerTimeDelta.returns(1000);
+      Socket.prototype.getServerTimeDelta.returns(1000);
       competitions = new Competitions;
     });
 
@@ -204,7 +204,7 @@ describe('competitions module', function () {
         'server time delta', function () {
       sandbox.clock.tick(1470230514177);
       expect(competitions.getRemainingTime.bind(competitions, null)).to.throw(TypeError);
-      Auth.prototype.getServerTimeDelta.returns(null);
+      Socket.prototype.getServerTimeDelta.returns(null);
       expect(competitions.getRemainingTime.bind(competitions, 1470230614))
         .to.throw(Error);
     });

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -287,39 +287,5 @@ describe('competitions module', function () {
       competitions._notify(1338);
       expect(Competitions.prototype._createNotification).to.not.been.called;
     });
-
-    it('should update the competition start time on the ' +
-        '"gamelist/gameUpdated" socket event', function () {
-      competitions._hash = {
-        1337: {
-          id: 1337,
-          beginTime: null,
-          ratingValue: 1,
-        },
-      };
-      competitions._processUpdated({
-        g: 1337,
-        diff: {
-          begintime: 1,
-        },
-      });
-      expect(competitions._hash[1337].beginTime).to.be.equal(1);
-      competitions._processUpdated({
-        g: 1338,
-        diff: {
-          begintime: 2,
-        },
-      });
-      expect(competitions._hash[1337].beginTime).to.be.equal(1);
-    });
-
-    it('should add competition data on the "gamelist/gameCreated" ' +
-        'socket event');
-
-    it('should process the gamelist data on the "gamelist/initList" ' +
-        'socket event');
-
-    it('should subscribe for gamelist changes if the user ' +
-        'is authorized');
   });
 });

--- a/tests/unit/background/socket.js
+++ b/tests/unit/background/socket.js
@@ -21,6 +21,7 @@ describe('socket module', function () {
       sandbox.spy(global, 'WebSocket');
       sandbox.spy(global, 'CustomEvent');
       sandbox.spy(kango.console, 'log');
+      sandbox.spy(kango, 'dispatchMessage');
       sandbox.stub(WebSocket.prototype, 'send');
       sandbox.stub(WebSocket.prototype, 'close');
       sandbox.stub(WebSocket.prototype, 'dispatchEvent');
@@ -206,17 +207,22 @@ describe('socket module', function () {
       expect(spy).to.have.been.calledTwice;
     });
 
-    it('should log a message and call the custom onError function ' +
+    it('should log a message and broadcast a SocketError event ' +
         'on any WebSocket error', function () {
-      var spy = sinon.spy();
-      socket.onError = spy;
       socket.connect(1337, '1337');
       socket._ws.onerror({ detail: { code: 4000, reason: 'Connection closed.' } });
-      expect(spy)
-        .to.have.been
-        .calledWithExactly({ detail: { code: 4000, reason: 'Connection closed.' } });
       expect(kango.console.log)
         .to.have.been.calledWithExactly('A WebSocket error has occured.');
+      expect(kango.dispatchMessage)
+        .to.have.been
+        .calledWithExactly('SocketError',
+          { detail: { code: 4000, reason: 'Connection closed.' } });
     });
+
+    it('should call the connect() method on the AuthStateChanged event, if the user ' +
+        'is authorized');
+
+    it('should call the disconnect() method on the AuthStateChanged event, if the user ' +
+        'is not authorized');
   });
 });

--- a/tests/unit/background/socket.js
+++ b/tests/unit/background/socket.js
@@ -62,14 +62,13 @@ describe('socket module', function () {
       return expect(promise).to.be.rejectedWith('auth failed');
     });
 
-    it('should return correct server time delta with getServerTimeDelta() ' +
-        'method', function () {
+    it('should broadcast a ServerTimeDelta event with correct time delta', function () {
       sandbox.clock.tick(1000);
       var promise = socket.connect(1337, '7331');
       socket._ws.onopen();
-      expect(socket.getServerTimeDelta()).to.be.null;
       socket._ws.onmessage({ data: 'a["time 2000"]' });
-      return expect(socket.getServerTimeDelta()).to.be.equal(1000);
+      return expect(kango.dispatchMessage)
+        .to.have.been.calledWithExactly('ServerTimeDelta', 1000);
     });
 
     it('should reject connect() promise if the WebSocket was closed ' +
@@ -95,28 +94,30 @@ describe('socket module', function () {
         'process', function () {
       // Stubbing the _auth method to avoid extra call of the WebSocket.prototype.send:
       sandbox.stub(Socket.prototype, '_auth');
-      socket.connect(1337, '7331');
-      socket.on('someEvent', function () {});
+      socket._subscribe({ data: { missedSubscribe: function () {} } });
+      var promise = socket.connect(1337, '7331');
+      socket._subscribe({ data: { missedSubscribe: function () {} } });
       socket._ws.onopen();
+      socket._subscribe({ data: { missedSubscribe: function () {} } });
       expect(WebSocket.prototype.send).to.have.not.been.called;
       socket._ws.onmessage({ data: 'a["auth ok"]' });
-      expect(WebSocket.prototype.send).to.have.been.calledOnce
-        .to.have.been.calledWithExactly('["subscribe someEvent"]');
+      return promise.then(function () {
+        socket._subscribe({ data: { someEvent: function () {} } });
+        expect(WebSocket.prototype.send).to.have.been.calledOnce
+          .to.have.been.calledWithExactly('["subscribe someEvent"]');
+      });
     });
 
     it('should send a subscribe message only once per event type', function () {
       // Stubbing the _auth method to avoid extra call of the WebSocket.prototype.send:
       sandbox.stub(Socket.prototype, '_auth');
-      socket.on('someEvent1', function () {});
       var promise = socket.connect(1337, '7331');
-      socket.on('someEvent2', function () {});
-      socket._ws.onopen();
-      socket.on('someEvent2', function () {});
-      socket.on('someEvent1', function () {});
       socket._ws.onmessage({ data: 'a["auth ok"]' });
       return promise.then(function () {
-        socket.on('someEvent2', function () {});
-        socket.on('someEvent3', function () {});
+        socket._subscribe({ data: { someEvent1: function () {} } });
+        socket._subscribe({ data: { someEvent2: function () {} } });
+        socket._subscribe({ data: { someEvent2: function () {} } });
+        socket._subscribe({ data: { someEvent3: function () {} } });
         expect(WebSocket.prototype.send).to.have.been.calledThrice
           .to.have.been.calledWithExactly('["subscribe someEvent1"]')
           .to.have.been.calledWithExactly('["subscribe someEvent2"]')
@@ -127,13 +128,13 @@ describe('socket module', function () {
     it('should broadcast an event message to all subscribers', function () {
       var spy1 = sinon.spy();
       var spy2 = sinon.spy();
-      socket.on('someEvent1', spy1);
       var promise = socket.connect(1337, '7331');
-      socket.on('someEvent1', spy1);
       socket._ws.onopen();
       socket._ws.onmessage({ data: 'a["auth ok"]' });
       return promise.then(function () {
-        socket.on('someEvent2', spy2);
+        socket._subscribe({ data: { someEvent1: spy1 } });
+        socket._subscribe({ data: { someEvent1: spy1 } });
+        socket._subscribe({ data: { someEvent2: spy2 } });
         socket._ws.onmessage({ data: 'a["[\\"someEvent1\\",{\\"message\\":1}]"]' });
         socket._ws.onmessage({ data: 'a["[\\"someEvent2\\",{\\"message\\":2}]"]' });
         expect(spy1).to.have.been.calledTwice
@@ -145,11 +146,11 @@ describe('socket module', function () {
 
     it('should ignore all messages with bad JSON', function () {
       var spy1 = sinon.spy();
-      socket.on('someEvent1', spy1);
       var promise = socket.connect(1337, '7331');
       socket._ws.onopen();
       socket._ws.onmessage({ data: 'a["auth ok"]' });
       return promise.then(function () {
+        socket._subscribe({ data: { someEvent1: spy1 } });
         expect(function () {
           socket._ws.onmessage({ data: 'a["[\\"someEvent1\\",{\\"bad json]"]' });
         }).to.not.throw();

--- a/tests/unit/background/socket.js
+++ b/tests/unit/background/socket.js
@@ -225,5 +225,7 @@ describe('socket module', function () {
 
     it('should call the disconnect() method on the AuthStateChanged event, if the user ' +
         'is not authorized');
+
+    it('should call the disconnect() method on teardown');
   });
 });


### PR DESCRIPTION
- Removed tight coupling Auth ↔ Socket
- Removed tight coupling Socket ↔ Competitions and Socket ↔ Button
- Finally fixed the auth-state foreground script
- Added MutableModule class for adding `teardown`, `addMessageListener` and `setMessageListener` methods to the prototype
- Added CompetitionsWS and CompetitionsXHR classes
- Added UnreadPMCounter class (uses XHR requests for fetching the number of unread PMs)
- Added `useWebSockets` global setting. #23 