### PR TITLE
Python builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+kango
+build
+*.pyc
+.doit.db

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ klavotools-kango
 
 1. Установить Python 2.7 (http://www.python.org/download/).
 2. Установить модуль [doit](https://pypi.python.org/pypi/doit):
-```
-pip install doit
-```
+    ```
+    pip install doit
+    ```
 3. Выполнить в корневой директории проекта команду:
-```
-doit
-```
+    ```
+    doit
+    ```
 
 Если все пройдет успешно, то появится директория `build` с готовыми к установке архивами расширений.
 

--- a/README.md
+++ b/README.md
@@ -3,26 +3,24 @@ klavotools-kango
 
 [![Build Status](https://api.travis-ci.org/Fenex/klavotools-kango.svg?branch=master)](https://travis-ci.org/Fenex/klavotools-kango)
 
-Кроссбраузерное расширение для сайта Клавогонки.ру
+Кроссбраузерное расширение для сайта [www.klavogonki.ru](http://www.klavogonki.ru)
 
 Сборка проекта
 -------------------
 
-###Инструкция
-1. Устанавливаем Python 2.7 (http://www.python.org/download/).
-2. Создаём где-нибудь папку `kango`, в ней папки `framework` и `klavotools`.
-3. Загружаем [отсюда](http://kangoextensions.com/kango/kango-1.7.3-public.zip) архив и распаковываем его в созданную папку `framework`. В папке `framework` должен находиться файл `kango.py`.
-4. Открываем шелл, переходим в созданную на шаге 2 папку `klavotools`.
-5. Создаём проект: `call "../framework/kango.py" create`. Называем его `klavotools`. Если всё прошло успешно, в папке `klavotools` должны быть две папки: `src` и `certificates`.
-6. Клонируем репозиторий `klavotools-kango` в директорию: `%kangodir%/klavotools/src/common/`.
-7. Создаём пакетный файл `build.cmd` в директории `%kangodir%/klavotools/` со содержимым, описанным разделом ниже.
-8. Запускаем файл `build.cmd`. Если всё пройдёт успешно, то появится директория `output`, в ней готовые к установке архивы расширений.
+Для сборки необходимо:
 
-###build.cmd
+1. Установить Python 2.7 (http://www.python.org/download/).
+2. Установить модуль [doit](https://pypi.python.org/pypi/doit):
+```
+pip install doit
+```
+3. Выполнить в корневой директории проекта команду:
+```
+doit
+```
 
-    @echo off
-    set kts=%~d0%~p0
-    call "%kts%\..\framework\kango.py" build .\
+Если все пройдет успешно, то появится директория `build` с готовыми к установке архивами расширений.
 
 Userstyles
 ----------

--- a/dodo.py
+++ b/dodo.py
@@ -1,0 +1,96 @@
+from doit.tools import run_once
+from urllib import urlretrieve
+from zipfile import ZipFile
+from tempfile import mkstemp, mkdtemp
+from subprocess import Popen, PIPE
+from shutil import rmtree, copytree, move, ignore_patterns
+from os import path, close, remove, listdir, makedirs
+
+KANGO_ARCHIVE_URL = 'http://kangoextensions.com/kango/kango-framework-latest.zip'
+KANGO_DIR = 'kango'
+KANGO_BIN = path.abspath(path.join(KANGO_DIR, 'kango.py'))
+BUILD_DIR = 'build'
+BUILD_IGNORE = (
+    '.*',
+    '*.py',
+    '*.pyc',
+    'kango',
+    'build',
+    'package.json',
+    'node_modules',
+    'tests',
+)
+
+def installKango(url, targetDir):
+    handle, tempName = mkstemp('.zip')
+    urlretrieve(url, tempName)
+    archive = ZipFile(tempName)
+    archive.extractall(targetDir)
+    archive.close()
+    close(handle)
+    remove(tempName)
+
+def bootstrapProject(kango, buildDir):
+    pipe = Popen(['python', kango, 'create'], stdout=PIPE, stdin=PIPE, cwd=buildDir)
+    pipe.communicate('TemporaryProject\0')
+
+def prepareProjectFiles(targetDir, ignore=()):
+    """Replaces targetDir directory contents with project files for building"""
+    removeDirectory(targetDir) # Clean the existing target directory first
+    copytree('.', targetDir, ignore=ignore_patterns(*ignore))
+
+def buildProject(kango, targetDir, outputDir):
+    pipe = Popen(['python', kango, 'build', '.'], cwd=targetDir)
+    pipe.communicate(None)
+
+def moveFiles(srcDir, destDir):
+    """Moves files from srcDir to destDir. Replaces existing files"""
+    files = listdir(srcDir)
+    if not path.exists(destDir):
+        makedirs(destDir)
+    for fileName in files:
+        pathName = path.join(srcDir, fileName)
+        if path.isfile(pathName):
+            move(pathName, path.join(destDir, fileName))
+
+def removeDirectory(targetDir):
+    rmtree(targetDir)
+
+def task_buildExtension():
+    """Builds the extension in the temporary directory."""
+    tempDir = mkdtemp()
+    targetDir = path.join(tempDir, 'src', 'common')
+    outputDir = path.join(tempDir, 'output')
+    yield {
+        'name': 'bootstrap',
+        'actions': [(bootstrapProject, [KANGO_BIN, tempDir])],
+        'task_dep': ['installKangoFramework'],
+    }
+    yield {
+        'name': 'prepare',
+        'actions': [(prepareProjectFiles, [targetDir, BUILD_IGNORE])],
+        'task_dep': ['buildExtension:bootstrap'],
+    }
+    yield {
+        'name': 'build',
+        'actions': [(buildProject, [KANGO_BIN, tempDir, outputDir])],
+        'task_dep': ['buildExtension:prepare'],
+    }
+    yield {
+        'name': 'move',
+        'actions': [(moveFiles, [outputDir, BUILD_DIR])],
+        'task_dep': ['buildExtension:build'],
+    }
+    yield {
+        'name': 'cleanup',
+        'actions': [(removeDirectory, [tempDir])],
+        'task_dep': ['buildExtension:move'],
+    }
+
+def task_installKangoFramework():
+    """Downloads and unpacks the Kango framework."""
+    return {
+        'actions': [(installKango, [KANGO_ARCHIVE_URL, KANGO_DIR])],
+        'targets': [KANGO_BIN],
+        'uptodate': [run_once],
+    }


### PR DESCRIPTION
Added [doit](https://pypi.python.org/pypi/doit)-based project builder. It automatically downloads and unpacks kango framework to the `kango` directory and builds extensions with only required files.

ref https://github.com/Fenex/klavotools-kango/pull/20#issuecomment-236775076