### PR TITLE
Fixed an issue with WebSocket connection

### DIFF
--- a/extension_info.json
+++ b/extension_info.json
@@ -29,7 +29,7 @@
         "klavotools/foreground/context-menu.js"
     ],
     "homepage_url": "http://klavogonki.ru/",
-    "version": "3.4.3",
+    "version": "3.4.4",
     "browser_button": {
         "caption": "KlavoTools",
         "icon": "icons/button_default.png",

--- a/klavotools/background/socket.js
+++ b/klavotools/background/socket.js
@@ -93,14 +93,17 @@ Socket.prototype._subscribe = function (message) {
  */
 Socket.prototype._onHeartbeat = function () {
     clearTimeout(this._heartbeatTimer);
-    this._heartbeatTimer = setTimeout(function () {
-        this._ws.dispatchEvent(new CustomEvent('error', {
-            detail: {
-                code: 4000,
-                reason: 'Connection closed by client due to server inactivity.',
-            }
-        }));
-    }.bind(this), KlavoTools.const.WS_HEARTBEAT_TIMEOUT * 1000);
+    // FIXME: after the last site update, server doesn't send heartbeat frames
+    // anymore (maybe a bug?). Needs additional investigation.
+    //
+    // this._heartbeatTimer = setTimeout(function () {
+    //     this._ws.dispatchEvent(new CustomEvent('error', {
+    //         detail: {
+    //             code: 4000,
+    //             reason: 'Connection closed by client due to server inactivity.',
+    //         }
+    //     }));
+    // }.bind(this), KlavoTools.const.WS_HEARTBEAT_TIMEOUT * 1000);
 };
 
 /**

--- a/klavotools/options/module.js
+++ b/klavotools/options/module.js
@@ -186,13 +186,15 @@ angular.module('klavotools', ['klavotools.joke', 'fnx.kango-q'])
     };
 
     $scope.$watch('delay', function(a, b) {
-        if(typeof b != 'object')
+        if (typeof b != 'object') {
             sendPrefs({delay: parseInt(a)});
+        }
     });
 
-    $scope.$watch('audio', function(a) {
-        if(typeof b != 'object')
+    $scope.$watch('audio', function(a, b) {
+        if (typeof b != 'object') {
             sendPrefs({audio: a});
+        }
     });
 })
 .filter('filterByTags', function () {

--- a/tests/unit/background/socket.js
+++ b/tests/unit/background/socket.js
@@ -161,7 +161,7 @@ describe('socket module', function () {
       });
     });
 
-    it('should raise a WebSocket error, if the heartbeat frame was not received after ' +
+    it.skip('should raise a WebSocket error, if the heartbeat frame was not received after ' +
         '40 seconds', function () {
       socket.connect(1337, '1337');
       socket._ws.onopen();


### PR DESCRIPTION
- Temporarily disabled a heartbeat frames check (after the last site update, server doesn't send heartbeat frames anymore).
- Fixed a bug with the options page (an argument declaration was missed in the ```$watch``` callback for the ```audio``` scope variable. The former caused strange behaviour of the competitions notifications after the options page was reloaded).