### PR TITLE
Filtering competitions notifications by the participants number

### DIFF
--- a/extension_info.json
+++ b/extension_info.json
@@ -29,7 +29,7 @@
         "klavotools/foreground/context-menu.js"
     ],
     "homepage_url": "http://klavogonki.ru/",
-    "version": "3.4.4",
+    "version": "3.4.5",
     "browser_button": {
         "caption": "KlavoTools",
         "icon": "icons/button_default.png",

--- a/extension_info.json
+++ b/extension_info.json
@@ -29,7 +29,7 @@
         "klavotools/foreground/context-menu.js"
     ],
     "homepage_url": "http://klavogonki.ru/",
-    "version": "3.4.3",
+    "version": "3.4.4",
     "browser_button": {
         "caption": "KlavoTools",
         "icon": "icons/button_default.png",

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -126,9 +126,19 @@ Competitions.prototype._createNotification = function (competition, remainingTim
     });
 
     notification.onclick = function () {
-        kango.browser.tabs.create({
-            url: 'http://klavogonki.ru/g/?gmid=' + competition.id,
-            focused: true,
+        var competitionUrl = 'http://klavogonki.ru/g/?gmid=' + competition.id;
+        // TODO: refactor navigate/tabs.create check:
+        kango.browser.tabs.getCurrent(function (tab) {
+            // Using private _tab property check because kango .getUrl() method is awful:
+            if (!tab._tab || tab.getUrl().search(/klavogonki.ru/) === -1) {
+                kango.browser.tabs.create({
+                    url: competitionUrl,
+                    focused: true,
+                });
+            } else {
+                // Navigate to the competition page without creating new tab:
+                tab.navigate(competitionUrl);
+            }
         });
         notification.revoke();
     };

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -128,16 +128,20 @@ Competitions.prototype._createNotification = function (competition, remainingTim
     notification.onclick = function () {
         var competitionUrl = 'http://klavogonki.ru/g/?gmid=' + competition.id;
         // TODO: refactor navigate/tabs.create check:
-        kango.browser.tabs.getCurrent(function (tab) {
-            // Using private _tab property check because kango .getUrl() method is awful:
-            if (!tab._tab || tab.getUrl().search(/klavogonki.ru/) === -1) {
+        kango.browser.tabs.getAll(function (tabs) {
+            var foundTab = tabs.find(function (tab) {
+                return tab._tab && tab.getUrl().search(/klavogonki.ru/) !== -1;
+            });
+            if (!foundTab) {
                 kango.browser.tabs.create({
                     url: competitionUrl,
                     focused: true,
                 });
             } else {
                 // Navigate to the competition page without creating new tab:
-                tab.navigate(competitionUrl);
+                foundTab.navigate(competitionUrl);
+                // Set the focus on this tab:
+                foundTab.activate();
             }
         });
         notification.revoke();

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -127,32 +127,7 @@ Competitions.prototype._createNotification = function (competition, remainingTim
 
     notification.onclick = function () {
         var competitionUrl = 'http://klavogonki.ru/g/?gmid=' + competition.id;
-        var re = /klavogonki.ru/;
-        // TODO: refactor navigate/tabs.create check:
-        kango.browser.tabs.getAll(function (tabs) {
-            var foundTab = tabs.find(function (tab) {
-                return tab._tab && tab.getUrl().search(re) !== -1;
-            });
-            var foundCurrentTab = tabs.find(function (tab) {
-                return tab._tab && tab.isActive() && tab.getUrl().search(re) !== -1;
-            });
-
-            if (foundCurrentTab) {
-                foundTab = foundCurrentTab;
-            }
-
-            if (!foundTab) {
-                kango.browser.tabs.create({
-                    url: competitionUrl,
-                    focused: true,
-                });
-            } else {
-                // Navigate to the competition page without creating new tab:
-                foundTab.navigate(competitionUrl);
-                // Set the focus on this tab:
-                foundTab.activate();
-            }
-        });
+        KlavoTools.tabs.createOrNavigateExisting(competitionUrl);
         notification.revoke();
     };
 

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -8,10 +8,14 @@
  */
 var Competitions = function() {
     // Set default values:
+    // TODO: move these options to a hash object:
     this.rates = kango.storage.getItem('competition_rates') || [3, 5]; //x3, x5
     this.delay = kango.storage.getItem('competition_delay');
     this.displayTime = kango.storage.getItem('competition_displayTime');
     this.audio = !!kango.storage.getItem('competition_audio');
+    this.onlyWithPlayers = kango.storage.getItem('competition_onlyWithPlayers') || false;
+    this.minimalPlayersNumber = kango.storage.getItem('competition_minimalPlayersNumber') || 2;
+
     if (typeof this.delay != 'number') {
         // 1 minute:
         this.delay = 60;
@@ -54,7 +58,9 @@ Competitions.prototype.getParams = function() {
         rates: this.rates,
         delay: this.delay,
         displayTime: this.displayTime,
-        audio: this.audio
+        audio: this.audio,
+        onlyWithPlayers: this.onlyWithPlayers,
+        minimalPlayersNumber: this.minimalPlayersNumber,
     };
 };
 
@@ -74,10 +80,20 @@ Competitions.prototype.setParams = function (param) {
         this.delay = param.delay;
     }
 
+    if (typeof param.onlyWithPlayers === 'boolean') {
+        this.onlyWithPlayers = param.onlyWithPlayers;
+    }
+
+    if (typeof param.minimalPlayersNumber === 'number') {
+        this.minimalPlayersNumber = param.minimalPlayersNumber;
+    }
+
     kango.storage.setItem('competition_delay', this.delay);
     kango.storage.setItem('competition_rates', this.rates);
     kango.storage.setItem('competition_displayTime', this.displayTime);
     kango.storage.setItem('competition_audio', this.audio);
+    kango.storage.setItem('competition_onlyWithPlayers', this.onlyWithPlayers);
+    kango.storage.setItem('competition_minimalPlayersNumber', this.minimalPlayersNumber);
 
     this._updateNotifications();
 };
@@ -96,6 +112,49 @@ Competitions.prototype._updateNotifications = function () {
             this._notify(id);
         }
     }
+}
+
+/**
+ * Fetches the number of active players in the given competition, with their logins list.
+ * @param {CompetitionData} competition A hash object with competition data
+ * @returns {Promise.<Object>} A promise to a hash object with number and logins fields
+ */
+Competitions.prototype._fetchPlayersData = function (competition) {
+    function processGamelistData(data) {
+        if (!Array.isArray(data.gamelist)) {
+            throw new Error('Competitions._checkPlayersNumber: data.gamelist not found.');
+        }
+
+        var found = data.gamelist.find(function(game) {
+            return game.id === competition.id;
+        });
+
+        if (!found) {
+            throw new Error('Competitions._checkPlayersNumber: ' +
+                'Competition #' + competition.id + ' not found.');
+        }
+
+        if (!Array.isArray(found.players)) {
+            throw new Error('Competitions._checkPlayersNumber: players array not available.');
+        }
+
+        var activePlayers = found.players.filter(function(player) {
+            return !player.leave;
+        });
+
+        return {
+            number: activePlayers.length,
+            logins: activePlayers.map(function (player) {
+                return player.name || '';
+            }),
+        };
+    }
+
+    return fetch(KlavoTools.const.GAMELIST_DATA_URL)
+        .then(function(response) {
+            return response.ok ? response.json() : Q.reject(response.json());
+        })
+        .then(processGamelistData.bind(this));
 };
 
 /**
@@ -120,6 +179,7 @@ Competitions.prototype._createNotification = function (competition, remainingTim
     }
 
     var notification = new DeferredNotification(title, {
+        audio: this.audio,
         body: body,
         icon: icon,
         displayTime: displayTime > 0 ? displayTime : void 0,
@@ -131,22 +191,48 @@ Competitions.prototype._createNotification = function (competition, remainingTim
         notification.revoke();
     };
 
-    notification.before = function () {
+    // Check if we are already at the competition page:
+    function checkPresence(competition) {
         var deferred = Q.defer();
         var re = new RegExp('klavogonki.ru/g/\\?gmid=' + competition.id + '$');
         kango.browser.tabs.getAll(function (tabs) {
-            // Check if we are already at the competition page:
-            var found = tabs.some(function (tab) {
+            deferred.resolve(tabs.some(function (tab) {
                 return tab._tab && tab.getUrl().search(re) !== -1;
-            });
-            // Play an audio notification if needed:
-            var audioUrl = kango.io.getResourceUrl('res/competition.ogg');
-            !found && this.audio && new Audio(audioUrl).play();
-            deferred.resolve(!found);
-        }.bind(this));
+            }));
+        });
         return deferred.promise;
-    }.bind(this);
+    }
 
+    function finalChecks(competition, notification) {
+        var deferred = Q.defer();
+
+        if (this.onlyWithPlayers) {
+            checkPresence(competition).then(function(alreadyThere) {
+                if (alreadyThere) {
+                    deferred.resolve(false);
+                }
+            }).then(this._fetchPlayersData.bind(this, competition))
+            .then(function(notification, data) {
+                // Updating the notification body:
+                if (data.number === 0) {
+                    notification.options.body += '\n(Нет активных участников)';
+                } else {
+                    notification.options.body += '\nУчастники (' + data.number + '): ' +
+                        data.logins.join(', ');
+                }
+
+                deferred.resolve(this.minimalPlayersNumber <= data.number);
+            }.bind(this, notification));
+        } else {
+            checkPresence(competition).then(function(alreadyThere) {
+                deferred.resolve(!alreadyThere);
+            });
+        }
+
+        return deferred.promise;
+    }
+
+    notification.before = finalChecks.bind(this, competition, notification);
     notification.show(showDelay);
 
     return notification;

--- a/klavotools/background/competitions.js
+++ b/klavotools/background/competitions.js
@@ -127,11 +127,20 @@ Competitions.prototype._createNotification = function (competition, remainingTim
 
     notification.onclick = function () {
         var competitionUrl = 'http://klavogonki.ru/g/?gmid=' + competition.id;
+        var re = /klavogonki.ru/;
         // TODO: refactor navigate/tabs.create check:
         kango.browser.tabs.getAll(function (tabs) {
             var foundTab = tabs.find(function (tab) {
-                return tab._tab && tab.getUrl().search(/klavogonki.ru/) !== -1;
+                return tab._tab && tab.getUrl().search(re) !== -1;
             });
+            var foundCurrentTab = tabs.find(function (tab) {
+                return tab._tab && tab.isActive() && tab.getUrl().search(re) !== -1;
+            });
+
+            if (foundCurrentTab) {
+                foundTab = foundCurrentTab;
+            }
+
             if (!foundTab) {
                 kango.browser.tabs.create({
                     url: competitionUrl,

--- a/klavotools/background/deferred-notification.js
+++ b/klavotools/background/deferred-notification.js
@@ -6,6 +6,7 @@
  *     body: 'Hello, world!',
  *     icon: 'http://example.com/img.png',
  *     displayTime: 10, // Hide the notification after 10 seconds
+ *     audio: true, // Play sound
  * });
  * notify.show(5); // Show the notification after 5 seconds
  * notify.onclick = function() {
@@ -19,6 +20,7 @@
  * window.Notification's constructor, with the addition of an optional parameters:
  *
  * @param {Number} [options.displayTime] Sets the display time for the notification in seconds
+ * @param {Boolean} [options.audio] Whether the sound notification is needed.
  * @param {string} title
  * @param {Object} options
  * @returns {Object}
@@ -80,6 +82,12 @@ DeferredNotification.prototype.show = function (delay) {
         // check whether the close event was triggered by user — saving the current timestamp:
         var timestamp = Date.now();
         var notification = new Notification(this.title, this.options);
+
+        // Play a sound if needed:
+        if (this.options.audio) {
+            new Audio(kango.io.getResourceUrl('res/competition.ogg')).play();
+        }
+
         this._notification = notification;
 
         // Proxing methods to the Notification instance object:

--- a/klavotools/background/engine.js
+++ b/klavotools/background/engine.js
@@ -38,6 +38,34 @@ KlavoTools.tabs = {
         kango.browser.tabs.getCurrent(function(tab) {
             tab.navigate(url);
         });
+    },
+    createOrNavigateExisting: function(url) {
+        var re = /klavogonki.ru/;
+        kango.browser.tabs.getAll(function (tabs) {
+            // Using private _tab property check because kango .getUrl() method is awful:
+            var foundTab = tabs.find(function (tab) {
+                return tab._tab && tab.getUrl().search(re) !== -1;
+            });
+            var foundCurrentTab = tabs.find(function (tab) {
+                return tab._tab && tab.isActive() && tab.getUrl().search(re) !== -1;
+            });
+
+            if (foundCurrentTab) {
+                foundTab = foundCurrentTab;
+            }
+
+            if (!foundTab) {
+                kango.browser.tabs.create({
+                    url: url,
+                    focused: true,
+                });
+            } else {
+                // Navigate to the given URL without creating new tab:
+                foundTab.navigate(url);
+                // Set the focus on this tab:
+                foundTab.activate();
+            }
+        });
     }
 };
 

--- a/klavotools/background/race-invitations.js
+++ b/klavotools/background/race-invitations.js
@@ -56,14 +56,30 @@ RaceInvitations.prototype._createNotification = function (game) {
 
     notification.onclick = function () {
         var raceUrl = 'http://klavogonki.ru/g/?gmid=' + game.game_id;
+        var re = /klavogonki.ru/;
         // TODO: refactor navigate/tabs.create check:
-        kango.browser.tabs.getCurrent(function (tab) {
-            // Using private _tab property check because kango .getUrl() method is awful:
-            if (!tab._tab || tab.getUrl().search(/klavogonki.ru/) === -1) {
-                kango.browser.tabs.create({ url: raceUrl });
+        kango.browser.tabs.getAll(function (tabs) {
+            var foundTab = tabs.find(function (tab) {
+                return tab._tab && tab.getUrl().search(re) !== -1;
+            });
+            var foundCurrentTab = tabs.find(function (tab) {
+                return tab._tab && tab.isActive() && tab.getUrl().search(re) !== -1;
+            });
+
+            if (foundCurrentTab) {
+                foundTab = foundCurrentTab;
+            }
+
+            if (!foundTab) {
+                kango.browser.tabs.create({
+                    url: raceUrl,
+                    focused: true,
+                });
             } else {
                 // Navigate to the race page without creating new tab:
-                tab.navigate(raceUrl);
+                foundTab.navigate(raceUrl);
+                // Set the focus on this tab:
+                foundTab.activate();
             }
         });
         notification.close();

--- a/klavotools/background/race-invitations.js
+++ b/klavotools/background/race-invitations.js
@@ -56,12 +56,13 @@ RaceInvitations.prototype._createNotification = function (game) {
 
     notification.onclick = function () {
         var raceUrl = 'http://klavogonki.ru/g/?gmid=' + game.game_id;
+        // TODO: refactor navigate/tabs.create check:
         kango.browser.tabs.getCurrent(function (tab) {
             // Using private _tab property check because kango .getUrl() method is awful:
-            if (!tab._tab || tab.getUrl().search(/klavogonki.ru\/g\/\?gmid/) === -1) {
+            if (!tab._tab || tab.getUrl().search(/klavogonki.ru/) === -1) {
                 kango.browser.tabs.create({ url: raceUrl });
             } else {
-                // We are at the race page — navigate to the new one:
+                // Navigate to the race page without creating new tab:
                 tab.navigate(raceUrl);
             }
         });

--- a/klavotools/background/race-invitations.js
+++ b/klavotools/background/race-invitations.js
@@ -56,32 +56,7 @@ RaceInvitations.prototype._createNotification = function (game) {
 
     notification.onclick = function () {
         var raceUrl = 'http://klavogonki.ru/g/?gmid=' + game.game_id;
-        var re = /klavogonki.ru/;
-        // TODO: refactor navigate/tabs.create check:
-        kango.browser.tabs.getAll(function (tabs) {
-            var foundTab = tabs.find(function (tab) {
-                return tab._tab && tab.getUrl().search(re) !== -1;
-            });
-            var foundCurrentTab = tabs.find(function (tab) {
-                return tab._tab && tab.isActive() && tab.getUrl().search(re) !== -1;
-            });
-
-            if (foundCurrentTab) {
-                foundTab = foundCurrentTab;
-            }
-
-            if (!foundTab) {
-                kango.browser.tabs.create({
-                    url: raceUrl,
-                    focused: true,
-                });
-            } else {
-                // Navigate to the race page without creating new tab:
-                foundTab.navigate(raceUrl);
-                // Set the focus on this tab:
-                foundTab.activate();
-            }
-        });
+        KlavoTools.tabs.createOrNavigateExisting(raceUrl);
         notification.close();
     };
 };

--- a/klavotools/background/socket.js
+++ b/klavotools/background/socket.js
@@ -93,14 +93,17 @@ Socket.prototype._subscribe = function (message) {
  */
 Socket.prototype._onHeartbeat = function () {
     clearTimeout(this._heartbeatTimer);
-    this._heartbeatTimer = setTimeout(function () {
-        this._ws.dispatchEvent(new CustomEvent('error', {
-            detail: {
-                code: 4000,
-                reason: 'Connection closed by client due to server inactivity.',
-            }
-        }));
-    }.bind(this), KlavoTools.const.WS_HEARTBEAT_TIMEOUT * 1000);
+    // FIXME: after the last site update, server doesn't send heartbeat frames
+    // anymore (maybe a bug?). Needs additional investigation.
+    //
+    // this._heartbeatTimer = setTimeout(function () {
+    //     this._ws.dispatchEvent(new CustomEvent('error', {
+    //         detail: {
+    //             code: 4000,
+    //             reason: 'Connection closed by client due to server inactivity.',
+    //         }
+    //     }));
+    // }.bind(this), KlavoTools.const.WS_HEARTBEAT_TIMEOUT * 1000);
 };
 
 /**

--- a/klavotools/options/module.js
+++ b/klavotools/options/module.js
@@ -186,13 +186,15 @@ angular.module('klavotools', ['klavotools.joke', 'fnx.kango-q'])
     };
 
     $scope.$watch('delay', function(a, b) {
-        if(typeof b != 'object')
+        if (typeof b != 'object') {
             sendPrefs({delay: parseInt(a)});
+        }
     });
 
-    $scope.$watch('audio', function(a) {
-        if(typeof b != 'object')
+    $scope.$watch('audio', function(a, b) {
+        if (typeof b != 'object') {
             sendPrefs({audio: a});
+        }
     });
 })
 .filter('filterByTags', function () {

--- a/klavotools/options/module.js
+++ b/klavotools/options/module.js
@@ -148,6 +148,8 @@ angular.module('klavotools', ['klavotools.joke', 'fnx.kango-q'])
     $scope.delay = null;
     $scope.displayTime = null;
     $scope.audio = null;
+    $scope.onlyWithPlayers = null;
+    $scope.minimalPlayersNumber = null;
 
     $scope.rates = {
         x1: false,
@@ -160,6 +162,8 @@ angular.module('klavotools', ['klavotools.joke', 'fnx.kango-q'])
         $scope.delay = res.delay;
         $scope.displayTime = res.displayTime;
         $scope.audio = res.audio;
+        $scope.onlyWithPlayers = res.onlyWithPlayers;
+        $scope.minimalPlayersNumber = res.minimalPlayersNumber;
         for(var i=0; i<res.rates.length; i++) {
             if(typeof $scope.rates['x'+res.rates[i]] == 'boolean') {
                 $scope.rates['x'+res.rates[i]] = true;
@@ -185,15 +189,25 @@ angular.module('klavotools', ['klavotools.joke', 'fnx.kango-q'])
         sendPrefs({ displayTime: parseInt($scope.displayTime) });
     };
 
+    // TODO: refactor this ugly code:
     $scope.$watch('delay', function(a, b) {
         if (typeof b != 'object') {
-            sendPrefs({delay: parseInt(a)});
+            sendPrefs({ delay: parseInt(a) });
         }
     });
-
     $scope.$watch('audio', function(a, b) {
         if (typeof b != 'object') {
-            sendPrefs({audio: a});
+            sendPrefs({ audio: a });
+        }
+    });
+    $scope.$watch('onlyWithPlayers', function(a, b) {
+        if (typeof b != 'object') {
+            sendPrefs({ onlyWithPlayers: !!a });
+        }
+    });
+    $scope.$watch('minimalPlayersNumber', function(a, b) {
+        if (typeof b != 'object') {
+            sendPrefs({ minimalPlayersNumber: parseInt(a) });
         }
     });
 })

--- a/klavotools/popup/popup.js
+++ b/klavotools/popup/popup.js
@@ -162,7 +162,7 @@ angular.module('popup', [
         var url;
         if (hasAvatar) {
             url = 'http://i.klavogonki.ru/avatars/' + id;
-            url += size === 'small' ? '.gif' : '_big.png';
+            url += size === 'small' ? '.png' : '_big.png';
         } else {
             url = 'http://klavogonki.ru/img/';
             url += size === 'small' ? 'avatar_dummy_16.png' : 'avatar_dummy.gif';

--- a/klavotools/popup/popup.js
+++ b/klavotools/popup/popup.js
@@ -161,8 +161,8 @@ angular.module('popup', [
     return function (id, hasAvatar, size) {
         var url;
         if (hasAvatar) {
-            url = 'http://img.klavogonki.ru/avatars/' + id;
-            url += size === 'small' ? '.gif' : '_big.gif';
+            url = 'http://i.klavogonki.ru/avatars/' + id;
+            url += size === 'small' ? '.gif' : '_big.png';
         } else {
             url = 'http://klavogonki.ru/img/';
             url += size === 'small' ? 'avatar_dummy_16.png' : 'avatar_dummy.gif';

--- a/klavotools/popup/popup.js
+++ b/klavotools/popup/popup.js
@@ -60,7 +60,7 @@ angular.module('popup', [
             var url = scope.ngPath || attrs.ngPathStr;
             var mode = RedirectMode.UNDEFINED;
             var timer = null;
-            element.on('click', function (event) {
+            element.on('click auxclick', function(event) {
                 event.stopPropagation();
                 if (event.button==1) {
                     mode = RedirectMode.UNDEFINED;

--- a/klavotools/popup/popup.js
+++ b/klavotools/popup/popup.js
@@ -58,23 +58,9 @@ angular.module('popup', [
         },
         link: function (scope, element, attrs) {
             var url = scope.ngPath || attrs.ngPathStr;
-            var mode = RedirectMode.UNDEFINED;
-            var timer = null;
             element.on('click auxclick', function(event) {
                 event.stopPropagation();
-                if (event.button==1) {
-                    mode = RedirectMode.UNDEFINED;
-                    Redirect(url, RedirectMode.BACKGROUND);
-                    return;
-                }
-                mode++;
-                if (!timer) {
-                    timer = $timeout(function () {
-                        Redirect(url, mode);
-                        mode = RedirectMode.UNDEFINED;
-                        timer = null;
-                    }, 300);
-                }
+                return event.button === 1 ? Redirect(url, RedirectMode.BACKGROUND) : Redirect(url);
             });
         }
     }

--- a/options.html
+++ b/options.html
@@ -136,6 +136,14 @@
           </td>
         </tr>
       </table>
+      <div>
+        <label>
+          <input type="checkbox" ng-model="onlyWithPlayers"/>
+          Уведомлять о рейтинговом соревновании только при наличии
+          <input type="number" min="0" ng-model="minimalPlayersNumber" class="number-input" ng-disabled="!onlyWithPlayers"/>
+          и более участников
+        </label>
+      </div>
       <div id="KTS_raceInvitations" ng:controller="RaceInvitations">
         <div ng:repeat="setting in settings">
           <div ng-if="setting.type === 'boolean'">

--- a/res/options.css
+++ b/res/options.css
@@ -230,6 +230,9 @@ h4 {
   font-style: italic;
   font-size: 11pt;
 }
+.number-input {
+  width: 4.5em;
+}
 .tag {
   position: relative;
   margin-right: 0.5ch;

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -23,7 +23,8 @@ describe('competitions module', function () {
       sandbox.stub(kango.storage, 'getItem');
       sandbox.stub(kango.xhr, 'send');
       sandbox.spy(kango.storage, 'setItem');
-      sandbox.spy(kango.browser.tabs, 'create');
+
+      sandbox.stub(KlavoTools.tabs, 'createOrNavigateExisting');
       sandbox.spy(Competitions.prototype, '_updateNotifications');
       sandbox.spy(Competitions.prototype, '_createNotification');
       // Setting up a spy for the DeferredNotification class constructor:
@@ -159,13 +160,10 @@ describe('competitions module', function () {
       // Default delay is set to 1 minute:
       expect(DeferredNotification.prototype.show)
         .to.have.been.calledWithExactly(340);
-      // TODO: Check the notification's click handler:
-      // notification.onclick();
-      // expect(kango.browser.tabs.create)
-      //   .to.have.been.calledWithExactly({
-      //     url: 'http://klavogonki.ru/g/?gmid=1337',
-      //     focused: true,
-      //   });
+      // Check the notification's click handler:
+      notification.onclick();
+      expect(KlavoTools.tabs.createOrNavigateExisting)
+        .to.have.been.calledWithExactly('http://klavogonki.ru/g/?gmid=1337');
       // Check the case with a huge displayTime:
       kango.storage.getItem.withArgs('competition_displayTime').returns(500);
       competitions = new Competitions;

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -159,13 +159,13 @@ describe('competitions module', function () {
       // Default delay is set to 1 minute:
       expect(DeferredNotification.prototype.show)
         .to.have.been.calledWithExactly(340);
-      // Check the notification's click handler:
-      notification.onclick();
-      expect(kango.browser.tabs.create)
-        .to.have.been.calledWithExactly({
-          url: 'http://klavogonki.ru/g/?gmid=1337',
-          focused: true,
-        });
+      // TODO: Check the notification's click handler:
+      // notification.onclick();
+      // expect(kango.browser.tabs.create)
+      //   .to.have.been.calledWithExactly({
+      //     url: 'http://klavogonki.ru/g/?gmid=1337',
+      //     focused: true,
+      //   });
       // Check the case with a huge displayTime:
       kango.storage.getItem.withArgs('competition_displayTime').returns(500);
       competitions = new Competitions;

--- a/tests/unit/background/competitions.js
+++ b/tests/unit/background/competitions.js
@@ -64,7 +64,9 @@ describe('competitions module', function () {
         rates: [1, 2, 3, 5],
         delay: 15,
         displayTime: 5,
-        audio: false
+        audio: false,
+        onlyWithPlayers: false,
+        minimalPlayersNumber: 2,
       });
     });
 
@@ -156,6 +158,7 @@ describe('competitions module', function () {
           // TODO: set the stub for the kango.io.getResourceUrl
           icon: undefined,
           displayTime: undefined,
+          audio: false,
         });
       // Default delay is set to 1 minute:
       expect(DeferredNotification.prototype.show)
@@ -174,6 +177,7 @@ describe('competitions module', function () {
           icon: undefined,
           // displayTime == delay:
           displayTime: 60,
+          audio: false,
         });
       // Check the case with a huge delay:
       kango.storage.getItem.withArgs('competition_delay').returns(500);

--- a/tests/unit/background/socket.js
+++ b/tests/unit/background/socket.js
@@ -161,7 +161,7 @@ describe('socket module', function () {
       });
     });
 
-    it('should raise a WebSocket error, if the heartbeat frame was not received after ' +
+    it.skip('should raise a WebSocket error, if the heartbeat frame was not received after ' +
         '40 seconds', function () {
       socket.connect(1337, '1337');
       socket._ws.onopen();


### PR DESCRIPTION
- Temporarily disabled a heartbeat frames check (after the last site update, server doesn't send heartbeat frames anymore).
- Fixed a bug with the options page (an argument declaration was missed in the `$watch` callback for the `audio` scope variable. The former caused strange behaviour of the competitions notifications after the options page was reloaded).
- Changed LMB click behavior for popup links and notifications.
- Fixed an issue with MMB clicks on popup links.
- Added filtering competitions notifications by the participants number.